### PR TITLE
remove more chrome noisy traffic

### DIFF
--- a/src/ca/gc/cyber/kangooroo/KangoorooStandaloneRunner.java
+++ b/src/ca/gc/cyber/kangooroo/KangoorooStandaloneRunner.java
@@ -55,6 +55,13 @@ public class KangoorooStandaloneRunner {
         return log;
     }
 
+    private static List<String> filterString = List.of("https://accounts.google.com/ListAccounts",
+       "http://clients2.google.com/", 
+       "https://android.clients.google.com",
+       "https://www.google.com/async"
+    );
+
+
     public static KangoorooURLReport generateKangoorooReport(KangoorooResult result, Long processTime,
             URL url, String browserSettingName, BrowserSetting browserSetting, boolean sanitizeSession,
             List<String> messageLog) throws IOException {
@@ -68,8 +75,7 @@ public class KangoorooStandaloneRunner {
 
         // Chromebrowser makes noisy requests that is unrelated to the URL for get.
         // We will filter out these requests from the HAR file
-        HarUtils.removeRequestUrlEntries(result.getHar(), "https://accounts.google.com/ListAccounts");
-        HarUtils.removeRequestUrlEntries(result.getHar(), "http://clients2.google.com/");
+        HarUtils.removeRequestUrlEntries(result.getHar(), filterString);
 
         KangoorooURLReport kangoorooReport = null;
 

--- a/src/ca/gc/cyber/kangooroo/utils/io/net/http/HarUtils.java
+++ b/src/ca/gc/cyber/kangooroo/utils/io/net/http/HarUtils.java
@@ -413,7 +413,15 @@ public class HarUtils {
             .collect(Collectors.toList())
         );
 
+    }
 
+    public static void removeRequestUrlEntries(Har har, List<String> patterns) {
+                List<HarEntry> oldEntries = har.getLog().getEntries();
+
+        har.getLog().setEntries(
+            oldEntries.stream().filter(entry -> !patterns.stream().anyMatch(x -> entry.getRequest().getUrl().contains(x)))
+            .collect(Collectors.toList())
+        );
     }
 
     public static void removeResponseEntries(Har har, int code) {


### PR DESCRIPTION
Chrome browser makes many noisy traffics. I was unable to remove these traffic through profile and policy.

- I added `https://www.google.com/async` based on [this](https://chromium-review.googlesource.com/c/chromium/src/+/6825324/16..26/chrome/browser/autocomplete/aim_eligibility_service.cc#99) part of chromium code, where it seems that it is impossible to remove this traffic through policy or profile.

- I added `https://android.clients.google.com` based on [this](https://chromium-review.googlesource.com/c/chromium/src/+/2703040/6/chrome/browser/ui/app_list/search/arc/recommend_apps_fetcher_impl.cc#63).

