### PR TITLE
make private inner classes public

### DIFF
--- a/src/ca/gc/cyber/kangooroo/report/KangoorooURLReport.java
+++ b/src/ca/gc/cyber/kangooroo/report/KangoorooURLReport.java
@@ -84,7 +84,7 @@ public class KangoorooURLReport {
     }
 
     @Data 
-    class Experimentation {
+    public class Experimentation {
         Map<String, String> engineInfo;
         Parameters params;
         Execution execution;
@@ -106,7 +106,7 @@ public class KangoorooURLReport {
 
         @Data
         @AllArgsConstructor
-        class Parameters {
+        public class Parameters {
             String url;
             String browserSettingName;
             String windowSize;
@@ -119,7 +119,7 @@ public class KangoorooURLReport {
         
         @Data 
         @AllArgsConstructor
-        class Execution {
+        public class Execution {
             String status;
             List<String> messages;
             String startTime;
@@ -131,7 +131,7 @@ public class KangoorooURLReport {
 
     @Data
     @AllArgsConstructor
-    class Summary {
+    public class Summary {
 
         Map<String, Object> fetchResult;
         KangoorooURL requestedUrl;
@@ -146,7 +146,7 @@ public class KangoorooURLReport {
 
     @Data
     @AllArgsConstructor
-    class Captcha {
+    public class Captcha {
         Boolean isPresent;
         String service;
         Boolean solved;


### PR DESCRIPTION
Context: another project parsing the report.

When using the KangoorooURLReport class to parse the report, some fields cannot be read correctly because the inner classes (i.e. Summary) are private. I'm requesting making these inner classes public.
